### PR TITLE
Cleanup.

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -593,7 +593,7 @@ do local _ENV = idl
 	func.getUniformInfo
 		"void"
 		.handle "UniformHandle"
-		.info   "UniformInfo *"
+		.info   "UniformInfo *" { out }
 
 	func.destroy { cname = "destroy_uniform" }
 		"void"
@@ -605,7 +605,7 @@ do local _ENV = idl
 	func.getResult
 		"OcclusionQueryResult::Enum"
 		.handle "OcclusionQueryHandle"
-		.result "int32_t *"
+		.result "int32_t *" { out }
 
 	func.destroy { cname = "destroy_occlusion_query" }
 		"void"
@@ -740,7 +740,7 @@ do local _ENV = idl
 
 	func.Encoder.allocTransform
 		"uint32_t"
-		.transform "Transform"
+		.transform "Transform *" { out }
 		.num       "uint16_t"
 
 	func.Encoder.setUniform

--- a/test.lua
+++ b/test.lua
@@ -425,7 +425,7 @@ do local _ENV = idl
 
 	func.calcTextureSize
 		"void"
-		.info      "TextureInfo"
+		.info      "TextureInfo &" { out }
 		.width     "uint16_t"
 		.height    "uint16_t"
 		.depth     "uint16_t"
@@ -439,7 +439,7 @@ do local _ENV = idl
 		.mem   "const Memory *"
 		.flags "uint64_t"
 		.skip  "uint8_t"
-		.info  "TextureInfo"
+		.info  "TextureInfo &" { out }
 
 	func.createTexture2D
 		"TextureHandle"


### PR DESCRIPTION
There is issue with C cast of `info` variable at the end:

IDL:

```
BGFX_C_API void bgfx_calc_texture_size(bgfx_texture_info_t * _info, uint16_t _width, uint16_t _height, uint16_t _depth, bool _cubeMap, bool _hasMips, uint16_t _numLayers, bgfx_texture_format_t _format)
{
	bgfx::TextureInfo info;
	bgfx::calcTextureSize(info, _width, _height, _depth, _cubeMap, _hasMips, _numLayers, (bgfx::TextureFormat::Enum)_format);
	*_info = (bgfx_texture_info_t)info;
}
```

Manual:

```
BGFX_C_API void bgfx_calc_texture_size(bgfx_texture_info_t* _info, uint16_t _width, uint16_t _height, uint16_t _depth, bool _cubeMap, bool _hasMips, uint16_t _numLayers, bgfx_texture_format_t _format)
{
	bgfx::TextureInfo& info = *(bgfx::TextureInfo*)_info;
	bgfx::calcTextureSize(info, _width, _height, _depth, _cubeMap, _hasMips, _numLayers, bgfx::TextureFormat::Enum(_format) );
}
```